### PR TITLE
fix(ci): Don't bother not releasing

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -9,30 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  release_status:
-    name: Check version
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.output.outputs.status }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Parse Changelog
-        id: changelog
-        uses: mindsers/changelog-reader-action@v2.2.2
-        with:
-          version: Unreleased
-
-      - name: Output status
-        id: output
-        run: |
-          echo "Found version '${{ steps.changelog.outputs.version }}'"
-          echo "status=${{ steps.changelog.outputs.status }}" >> $GITHUB_OUTPUT
-
   build_client:
     name: Build Client
-    needs: release_status
-    if: needs.release_status.outputs.status != 'unreleased'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -72,8 +50,6 @@ jobs:
 
   build_server:
     name: Build Server
-    needs: release_status
-    if: needs.release_status.outputs.status != 'unreleased'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Ok, we'll release with every push for now, until we figure out a consistent way to parse the changelog for this.
+
 ## [0.16.2] - 2023-01-29
 ### Added
 - [security.txt](https://recorded.finance/.well-known/security.txt) file based on the spec described in [securitytxt.org](https://securitytxt.org).
@@ -396,6 +400,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
+[Unreleased]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.2...HEAD
 [0.16.2]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/RecordedFinance/recorded-finance/compare/v0.15.3...v0.16.0


### PR DESCRIPTION
For some reason, releases are hard. I want to do something robust there, and I don't want to introduce a race condition by checking whether a tag exists (when we have a job running at the same time that cuts tags), so for now we go back to the way things were.