### PR TITLE
Better record downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The app no longer redundantly recalculates caches on transaction documents that were unchanged for a given write. This means the transaction list reloads much faster for long transaction history when you make a change, like marking a transaction as "resolved".
+
 ### Security
 - Updated vulnerable dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.6] - 2023-02-18
 ### Fixed
 - The app no longer redundantly recalculates caches on transaction documents that were unchanged for a given write. This means the transaction list reloads much faster for long transaction history when you make a change, like marking a transaction as "resolved".
 
@@ -418,7 +418,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.5...HEAD
+[0.16.6]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.5...v0.16.6
 [0.16.5]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.2...v0.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Security
+- Updated vulnerable dependencies.
+
 ## [0.16.5] - 2023-02-17
 ### Added
 - The app now displays a big scary warning message in the devtools console. Nobody should be pasting stuff in there that strangers tell them to paste in, so we make that clear.
@@ -411,6 +415,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
+[Unreleased]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.5...HEAD
 [0.16.5]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/RecordedFinance/recorded-finance/compare/v0.16.2...v0.16.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.16.5",
+	"version": "0.16.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recorded-finance-client",
-			"version": "0.16.5",
+			"version": "0.16.6",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3611,9 +3611,9 @@
 			}
 		},
 		"node_modules/cookiejar": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
@@ -13453,9 +13453,9 @@
 			}
 		},
 		"cookiejar": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
 		},
 		"core-util-is": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.16.5",
+	"version": "0.16.6",
 	"license": "GPL-3.0",
 	"description": "A Svelte app for managing monetary assets.",
 	"scripts": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3648,9 +3648,9 @@
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
 		},
 		"node_modules/cookiejar": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
 		},
 		"node_modules/cookies": {
 			"version": "0.8.0",
@@ -6006,9 +6006,9 @@
 			"dev": true
 		},
 		"node_modules/http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
 		},
 		"node_modules/http-errors": {
@@ -13889,9 +13889,9 @@
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
 		},
 		"cookiejar": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
 		},
 		"cookies": {
 			"version": "0.8.0",
@@ -15570,9 +15570,9 @@
 			"dev": true
 		},
 		"http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
 		},
 		"http-errors": {

--- a/src/store/transactionsStore.ts
+++ b/src/store/transactionsStore.ts
@@ -146,7 +146,9 @@ export async function watchTransactions(account: Account, force: boolean = false
 
 				// Update cache
 				const accountTransactions = get(transactionsForAccount)[account.id] ?? {};
-				await asyncForEach(snap.docChanges(), async change => {
+				const changes = snap.docChanges();
+				logger.debug("snap.docChanges()", changes);
+				await asyncForEach(changes, async change => {
 					let balance = get(currentBalance)[account.id] ?? zeroDinero;
 
 					try {


### PR DESCRIPTION
Since making cryption calls `async`, I learned that _not_ properly diffing change snapshots makes for a _ton_ of decryption work on unchanged documents. This PR adds a basic naïve diff on change snaps. Table reloads should be much faster now on large transaction histories (tho still not yet where I think they can be).