### PR TITLE
chore: Move cryption structures somewhere that makes more sense

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 							cannot know what's in your wallet. This works entirely in the browser, using modern
 							standard JavaScript APIs. You can
 							<a
-								href="https://github.com/RecordedFinance/recorded-finance/tree/v0.16.0/src/transport/cryption.ts"
+								href="https://github.com/RecordedFinance/recorded-finance/blob/main/src/workers/cryptionWorker.ts"
 								target="_blank"
 								rel="noopener noreferrer"
 								>check the code yourself</a

--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -94,7 +94,9 @@
 					>{$_("home.how-we-work.spa")}</OutLink
 				>
 				<!-- read -->
-				<OutLink to={repoFile("src/transport/cryption.ts")}>{$_("home.how-we-work.read")}</OutLink>
+				<OutLink to={repoFile("src/workers/cryptionWorker.ts")}
+					>{$_("home.how-we-work.read")}</OutLink
+				>
 			</I18N>
 		</p>
 	</section>

--- a/src/Security.svelte
+++ b/src/Security.svelte
@@ -64,7 +64,7 @@
 					>{$_("security-faq.where-keys.pbkdf2")}</OutLink
 				>
 				<!-- source -->
-				<OutLink to={repoFile("src/transport/cryption.ts")}
+				<OutLink to={repoFile("src/transport/cryptionProtocols.ts")}
 					>{$_("security-faq.where-keys.source")}</OutLink
 				>
 			</I18N>

--- a/src/transport/HashStore.ts
+++ b/src/transport/HashStore.ts
@@ -2,7 +2,7 @@ import type { Opaque } from "type-fest";
 import atob from "atob-lite";
 import btoa from "btoa-lite";
 
-type Obfuscated = Opaque<string, "Obfuscated">;
+export type Obfuscated = Opaque<string, "Obfuscated">;
 
 /**
  * An object that stores a string value in base-64. Useful for

--- a/src/transport/accounts.ts
+++ b/src/transport/accounts.ts
@@ -5,7 +5,7 @@ import type {
 	WriteBatch,
 } from "./db";
 import type { Account, AccountRecordParams } from "../model/Account";
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import { account, isAccountRecord, recordFromAccount } from "../model/Account";
 import { encrypt } from "./cryption";

--- a/src/transport/attachments.ts
+++ b/src/transport/attachments.ts
@@ -6,7 +6,7 @@ import type {
 } from "./db";
 import type { Attachment, AttachmentRecordParams } from "../model/Attachment";
 import type { StorageReference } from "./storage.js";
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import type { UID } from "./schemas";
 import { attachment, isAttachmentRecord, recordFromAttachment } from "../model/Attachment";

--- a/src/transport/auth.ts
+++ b/src/transport/auth.ts
@@ -1,5 +1,5 @@
 import type { PlatformDB, DocumentReference } from "./db";
-import type { KeyMaterial } from "./cryption";
+import type { KeyMaterial } from "./cryptionProtocols";
 import type { MFAValidation, UID } from "./schemas";
 import { doc, db, getDoc, setDoc, deleteDoc } from "./db";
 import { isUid } from "./schemas";

--- a/src/transport/cryption.ts
+++ b/src/transport/cryption.ts
@@ -1,54 +1,26 @@
 import type CryptoJS from "crypto-js";
-import type { Opaque } from "type-fest";
+import type { EPackage, KeyMaterial, Salt } from "./cryptionProtocols";
+import type { Hashed } from "../workers/cryptionWorker";
+import type { Obfuscated } from "./HashStore";
+import { DecryptionError } from "./errors/DecryptionError";
+import { HashStore } from "./HashStore";
+import { isProbablyRawDecryptionError } from "./errors/RawDecryptionError";
 import { isString } from "../helpers/isString";
-import { HashStore } from "./HashStore.js";
 import { t } from "../i18n";
-import "crypto-js/sha512"; // to keep SHA512 algo from tree-shaking away
-import AES from "crypto-js/aes";
-import atob from "atob-lite";
-import btoa from "btoa-lite";
-import CryptoJSCore from "crypto-js/core";
-import EncBase64 from "crypto-js/enc-base64";
-import EncUtf8 from "crypto-js/enc-utf8";
-import PBKDF2 from "crypto-js/pbkdf2";
-import WordArray from "crypto-js/lib-typedarrays";
 
-type Hashed = Opaque<string, "Hashed">;
+// TODO: Make this a Comlink worker
+import * as worker from "../workers/cryptionWorker";
 
-const Protocols = {
-	v0: {
-		/**
-		 * crypto-js uses 32-bit words for PBKDF2
-		 *
-		 * See https://github.com/brix/crypto-js/blob/develop/docs/QuickStartGuide.wiki#sha-2
-		 * See also https://cryptojs.gitbook.io/docs/#pbkdf2
-		 */
-		wordSizeBits: 32,
-		keySizeBits: 8192, // my first aim was 256 bits, but that was actually WORDS, so this is the number of bits I was doing
-		saltSizeBytes: 32,
-		iterations: 10_000,
-		keyEncoding: EncBase64,
-		dataEncoding: EncUtf8,
-		hasher: CryptoJSCore.algo.SHA512,
-		cipher: AES,
-		derivation: PBKDF2,
-
-		/** Generates a cryptographically-secure random value. */
-		randomValue(byteCount: number): string {
-			return WordArray.random(byteCount).toString(EncBase64);
-		},
-	},
-} as const;
-
-const Cryption = Protocols.v0;
-
-type Salt = Opaque<string, "Salt">;
+async function wait(): Promise<void> {
+	await new Promise(resolve => setTimeout(resolve, 10));
+}
 
 /**
  * Makes special potatoes that are unique to the `input`.
  */
 export async function hashed(input: string): Promise<Hashed> {
-	return btoa((await derivePKey(input, "salt" as Salt)).value) as Hashed;
+	await wait();
+	return worker.hashed(input);
 }
 
 /**
@@ -58,15 +30,8 @@ export async function hashed(input: string): Promise<Hashed> {
  * @param salt A salt to make the final key more unique.
  */
 export async function derivePKey(password: string, salt: Salt): Promise<HashStore> {
-	await new Promise(resolve => setTimeout(resolve, 10)); // wait 10 ms for UI
-
-	return new HashStore(
-		Cryption.derivation(password, salt, {
-			iterations: Cryption.iterations,
-			hasher: Cryption.hasher,
-			keySize: Cryption.keySizeBits / Cryption.wordSizeBits,
-		}).toString(Cryption.keyEncoding)
-	);
+	await wait();
+	return HashStore.fromHashed(worker.derivePKey(password, salt));
 }
 
 /**
@@ -75,26 +40,11 @@ export async function derivePKey(password: string, salt: Salt): Promise<HashStor
  * @param pKey The key used to encrypt or decrypt the DEK.
  * @param ciphertext The encrypted DEK material.
  */
-export async function deriveDEK(pKey: HashStore, ciphertext: string): Promise<HashStore> {
+export async function deriveDEK(pKey: HashStore, ciphertext: Obfuscated): Promise<HashStore> {
 	const dekObject = await decrypt({ ciphertext }, pKey);
 	if (!isString(dekObject)) throw new TypeError(t("error.cryption.malformed-key"));
 
 	return new HashStore(atob(dekObject));
-}
-
-async function newDataEncryptionKeyMaterialForDEK(
-	password: string,
-	dek: HashStore
-): Promise<KeyMaterial> {
-	// To make passwords harder to guess
-	const passSalt = btoa(Cryption.randomValue(Cryption.saltSizeBytes)) as Salt;
-
-	// To encrypt the dek
-	const pKey = await derivePKey(password, passSalt);
-	const dekObject = btoa(dek.value);
-	const dekMaterial = (await encrypt(dekObject, "KeyMaterial", pKey)).ciphertext;
-
-	return { dekMaterial, passSalt };
 }
 
 /**
@@ -104,8 +54,8 @@ async function newDataEncryptionKeyMaterialForDEK(
  */
 export async function newDataEncryptionKeyMaterial(password: string): Promise<KeyMaterial> {
 	// To encrypt data
-	const dek = new HashStore(Cryption.randomValue(Cryption.keySizeBits / Cryption.wordSizeBits));
-	return await newDataEncryptionKeyMaterialForDEK(password, dek);
+	await wait();
+	return worker.newDataEncryptionKeyMaterial(password);
 }
 
 /**
@@ -121,16 +71,13 @@ export async function newMaterialFromOldKey(
 	newPassword: string,
 	oldKey: KeyMaterial
 ): Promise<KeyMaterial> {
-	const oldPKey = await derivePKey(oldPassword, oldKey.passSalt);
-	const dek = await deriveDEK(oldPKey, oldKey.dekMaterial);
-	const newPKey = await newDataEncryptionKeyMaterialForDEK(newPassword, dek);
-
-	return {
-		dekMaterial: newPKey.dekMaterial,
-		passSalt: newPKey.passSalt,
-		oldDekMaterial: oldKey.dekMaterial,
-		oldPassSalt: oldKey.passSalt,
-	};
+	try {
+		await wait();
+		return worker.newMaterialFromOldKey(oldPassword, newPassword, oldKey);
+	} catch (error) {
+		if (!isProbablyRawDecryptionError(error)) throw error;
+		throw new DecryptionError(error);
+	}
 }
 
 /**
@@ -146,37 +93,8 @@ export async function encrypt<T extends string>(
 	objectType: T,
 	dek: HashStore
 ): Promise<EPackage<T>> {
-	await new Promise(resolve => setTimeout(resolve)); // give UI a chance to breathe
-
-	const plaintext = JSON.stringify(data);
-	const ciphertext = Cryption.cipher.encrypt(plaintext, dek.value).toString();
-
-	return { ciphertext, objectType, cryption: "v0" };
-}
-
-class DecryptionError extends Error {
-	private constructor(message: string) {
-		super(message);
-		this.name = "DecryptionError";
-	}
-
-	static resultIsEmpty(): DecryptionError {
-		return new DecryptionError(t("error.cryption.empty-result"));
-	}
-
-	static parseFailed(error: unknown, plaintext: string): DecryptionError {
-		let message: string;
-		if (error instanceof Error) {
-			message = error.message;
-		} else {
-			message = JSON.stringify(error);
-		}
-		return new DecryptionError(
-			t("error.cryption.plaintext-not-json", {
-				values: { error: message, plaintext },
-			})
-		);
-	}
+	await wait();
+	return worker.encrypt(data, objectType, dek.hashedValue);
 }
 
 /**
@@ -190,52 +108,14 @@ export async function decrypt<T extends string>(
 	pkg: Pick<EPackage<T>, "ciphertext">,
 	dek: HashStore
 ): Promise<unknown> {
-	await new Promise(resolve => setTimeout(resolve)); // give UI a chance to breathe
-
-	const { ciphertext } = pkg;
-	const plaintext = Cryption.cipher.decrypt(ciphertext, dek.value).toString(Cryption.dataEncoding);
-
-	if (!plaintext) {
-		throw DecryptionError.resultIsEmpty();
-	}
+	await wait();
 
 	try {
-		return JSON.parse(plaintext) as unknown;
+		return worker.decrypt(pkg, dek.hashedValue);
 	} catch (error) {
-		throw DecryptionError.parseFailed(error, plaintext);
+		if (!isProbablyRawDecryptionError(error)) throw error;
+		throw new DecryptionError(error);
 	}
-}
-
-/**
- * User-level encryption material that lives on the server.
- * This data is useless without the user's password.
- */
-export interface KeyMaterial {
-	dekMaterial: string;
-	passSalt: Salt;
-	oldDekMaterial?: string;
-	oldPassSalt?: Salt;
-}
-
-export interface EPackage<T extends string> {
-	/**
-	 * The encrypted payload. This data should be unreadable without the user's password.
-	 */
-	ciphertext: string;
-
-	/** A string identifying to the application the type of data encoded. */
-	objectType: T;
-
-	/**
-	 * A string identifying the en/decryption protocol to use.
-	 *
-	 * If this value is not set, `"v0"` is assumed.
-	 *
-	 * `"v0"` uses an AES cipher with a 256-word key (with 32-bit words), a 32-bit salt,
-	 * and 10000 iterations of PBKDF2. Keys are encoded in Base64. Hashes are generated
-	 * using SHA-512.
-	 */
-	cryption?: "v0";
 }
 
 export type DEKMaterial = CryptoJS.lib.CipherParams;

--- a/src/transport/cryptionProtocols.ts
+++ b/src/transport/cryptionProtocols.ts
@@ -1,0 +1,189 @@
+import type { Obfuscated } from "./HashStore";
+import type { Opaque } from "type-fest";
+import { UnreachableCaseError } from "../transport/errors";
+import "crypto-js/sha512"; // to keep SHA512 algo from tree-shaking away
+import AES from "crypto-js/aes";
+import CryptoJSCore from "crypto-js/core";
+import EncBase64 from "crypto-js/enc-base64";
+import EncUtf8 from "crypto-js/enc-utf8";
+import PBKDF2 from "crypto-js/pbkdf2";
+import WordArray from "crypto-js/lib-typedarrays";
+
+// ** Our supported encryption layouts **
+
+export const Protocols = {
+	/**
+	 * Our proof-of-concept cryption protocol. #TODO: Migrate from this before our 1.0 release.
+	 */
+	v0: {
+		wordSizeBits: 32,
+		keySizeBits: 8192, // my aim was 256 bits, but I accidentally did WORDS instead lol
+		saltSizeBytes: 32,
+		iterations: 10_000,
+		keyEncoding: "base64",
+		dataEncoding: "utf8",
+		hasher: "sha512",
+		cipher: "aes",
+		derivation: PBKDF2,
+		randomValue,
+	} satisfies CryptionProtocol,
+
+	/**
+	 * Our first real cryption protocol. (These values are not yet final.)
+	 */
+	/*
+	v1: {
+		wordSizeBits: 32,
+		keySizeBits: 256,
+		saltSizeBytes: 32,
+		iterations: 600_000,
+		keyEncoding: "base64",
+		dataEncoding: "utf8",
+		hasher: "sha512",
+		cipher: "aes",
+		derivation: PBKDF2,
+		randomValue,
+	} satisfies CryptionProtocol,
+	*/
+};
+
+export type AvailableProtocols = keyof typeof Protocols;
+
+export interface CryptionProtocol {
+	/**
+	 * crypto-js uses 32-bit words for PBKDF2
+	 *
+	 * See https://github.com/brix/crypto-js/blob/develop/docs/QuickStartGuide.wiki#sha-2
+	 * See also https://cryptojs.gitbook.io/docs/#pbkdf2
+	 */
+	wordSizeBits: number;
+
+	/**
+	 * The number of bits that should comprise new cryptographic keys.
+	 */
+	keySizeBits: number;
+
+	/**
+	 * The number of bytes of random data to use for salts.
+	 */
+	saltSizeBytes: number;
+
+	/**
+	 * The number of iterations of our derivation function to use.
+	 */
+	iterations: number;
+
+	/**
+	 * How key strings should be encoded.
+	 */
+	keyEncoding: Encoding;
+
+	/**
+	 * How data strings should be encoded.
+	 */
+	dataEncoding: Encoding;
+
+	/**
+	 * The function used to create one-way hash values.
+	 */
+	hasher: HashAlg;
+
+	/**
+	 * The cipher function to use.
+	 */
+	cipher: Cipher;
+
+	/**
+	 * The function to use to derive keys from passwords or other secret values.
+	 */
+	derivation: typeof PBKDF2;
+
+	/** Generates a cryptographically-secure random value. */
+	randomValue(byteCount: number): string;
+}
+
+export type Salt = Opaque<string, "Salt">;
+
+/**
+ * User-level encryption material that lives on the server.
+ * This data is useless without the user's password.
+ */
+export interface KeyMaterial {
+	dekMaterial: Obfuscated;
+	passSalt: Salt;
+	oldDekMaterial?: Obfuscated;
+	oldPassSalt?: Salt;
+}
+
+export interface EPackage<T extends string> {
+	/**
+	 * The encrypted payload. This data should be unreadable without the user's password.
+	 */
+	ciphertext: string;
+
+	/** A string identifying to the application the type of data encoded. */
+	objectType: T;
+
+	/**
+	 * A string identifying the en/decryption protocol to use.
+	 *
+	 * If this value is not set, `"v0"` is assumed.
+	 *
+	 * `"v0"` uses an AES cipher with a 256-word key (with 32-bit words), a 32-bit salt,
+	 * and 10,000 iterations of PBKDF2. Keys are encoded in Base64. Hashes are generated
+	 * using SHA-512.
+	 *
+	 * `"v1"` is not yet well-defined, and should not be used.
+	 */
+	cryption?: AvailableProtocols;
+}
+
+// ** Getters for specific protocols and structures **
+
+export type Encoding = "base64" | "utf8";
+
+export type HashAlg = "sha512";
+
+export type Cipher = "aes";
+
+/**
+ * @returns a CryptoJS encoder from the given descriptor.
+ */
+export function encoder(type: Encoding): typeof EncBase64 {
+	switch (type) {
+		case "base64":
+			return EncBase64;
+		case "utf8":
+			return EncUtf8;
+		default:
+			throw new UnreachableCaseError(type);
+	}
+}
+
+/**
+ * @returns a CryptoJS hasher from the given descriptor.
+ */
+export function hasher(type: HashAlg): typeof CryptoJSCore.algo.SHA512 {
+	switch (type) {
+		case "sha512":
+			return CryptoJSCore.algo.SHA512;
+		default:
+			throw new UnreachableCaseError(type);
+	}
+}
+
+/**
+ * @returns a CryptoJS cipher from the given descriptor.
+ */
+export function cipher(type: Cipher): typeof AES {
+	switch (type) {
+		case "aes":
+			return AES;
+		default:
+			throw new UnreachableCaseError(type);
+	}
+}
+
+export function randomValue(byteCount: number): string {
+	return WordArray.random(byteCount).toString(encoder("base64"));
+}

--- a/src/transport/db.ts
+++ b/src/transport/db.ts
@@ -1,6 +1,6 @@
 import type { DataItem, Keys } from "./api.js";
 import type { DocumentData, DocumentWriteBatch } from "./schemas.js";
-import type { EPackage } from "./cryption.js";
+import type { EPackage } from "./cryptionProtocols.js";
 import type { HashStore } from "./HashStore.js";
 import type { Unsubscribe } from "./onSnapshot.js";
 import type { User } from "./auth.js";

--- a/src/transport/errors/DecryptionError.ts
+++ b/src/transport/errors/DecryptionError.ts
@@ -1,0 +1,13 @@
+import type { RawDecryptionError } from "./RawDecryptionError";
+import { t } from "../../i18n";
+
+export class DecryptionError extends Error {
+	/**
+	 * Constructs a new `DecryptionError` instance using a message
+	 * derived from the given {@link RawDecryptionError} object.
+	 */
+	constructor(raw: Pick<RawDecryptionError, "message" | "values">) {
+		super(t(raw.message, { values: raw.values }));
+		this.name = "DecryptionError";
+	}
+}

--- a/src/transport/errors/RawDecryptionError.ts
+++ b/src/transport/errors/RawDecryptionError.ts
@@ -1,0 +1,42 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { DecryptionError } from "./DecryptionError";
+
+/**
+ * An error thrown during decryption. Construct a {@link DecryptionError}
+ * for error messages in the user's own language.
+ */
+export class RawDecryptionError extends Error {
+	readonly values: Record<string, string> | undefined;
+
+	private constructor(message: string, values?: Record<string, string>) {
+		super(message);
+		this.values = values;
+		this.name = "RawDecryptionError";
+	}
+
+	static resultIsEmpty(): RawDecryptionError {
+		return new RawDecryptionError("error.cryption.empty-result");
+	}
+
+	static parseFailed(error: unknown, plaintext: string): RawDecryptionError {
+		let message: string;
+		if (error instanceof Error) {
+			message = error.message;
+		} else {
+			message = JSON.stringify(error);
+		}
+		return new RawDecryptionError("error.cryption.plaintext-not-json", {
+			error: message,
+			plaintext,
+		});
+	}
+
+	static malformedKey(): RawDecryptionError {
+		return new RawDecryptionError("error.cryption.malformed-key");
+	}
+}
+
+export function isProbablyRawDecryptionError(tbd: unknown): tbd is RawDecryptionError {
+	// Can't use `instanceof` directly, because this value might have been deserialized from a different context
+	return tbd instanceof Error && tbd.name === "RawDecryptionError";
+}

--- a/src/transport/errors/index.ts
+++ b/src/transport/errors/index.ts
@@ -1,5 +1,7 @@
+export * from "./DecryptionError.js";
 export * from "./NetworkError.js";
 export * from "./NotImplementedError.js";
 export * from "./PlatformError.js";
+export * from "./RawDecryptionError.js";
 export * from "./UnexpectedResponseError.js";
 export * from "./UnreachableCaseError.js";

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -2,6 +2,7 @@ export * from "./accounts";
 export * from "./attachments";
 export * from "./auth";
 export * from "./cryption";
+export * from "./cryptionProtocols";
 export * from "./db";
 export * from "./getDataAtUrl";
 export * from "./HashStore";

--- a/src/transport/locations.ts
+++ b/src/transport/locations.ts
@@ -1,4 +1,4 @@
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import type { Location, LocationRecordParams } from "../model/Location";
 import type { UID } from "./schemas";

--- a/src/transport/tags.ts
+++ b/src/transport/tags.ts
@@ -4,7 +4,7 @@ import type {
 	QueryDocumentSnapshot,
 	WriteBatch,
 } from "./db";
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import type { Tag, TagRecordParams } from "../model/Tag";
 import { encrypt } from "./cryption";

--- a/src/transport/transactions.ts
+++ b/src/transport/transactions.ts
@@ -1,4 +1,4 @@
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import type { Transaction, TransactionRecordParams } from "../model/Transaction";
 import type {

--- a/src/transport/userPrefs.ts
+++ b/src/transport/userPrefs.ts
@@ -1,5 +1,5 @@
 import type { DocumentReference, QueryDocumentSnapshot } from "./db";
-import type { EPackage } from "./cryption";
+import type { EPackage } from "./cryptionProtocols";
 import type { HashStore } from "./HashStore";
 import type { LocationPref } from "./locations";
 import type { UID } from "./schemas";

--- a/src/workers/cryptionWorker.ts
+++ b/src/workers/cryptionWorker.ts
@@ -1,0 +1,160 @@
+import type { EPackage, KeyMaterial, Salt } from "../transport/cryptionProtocols";
+import type { Obfuscated } from "../transport/HashStore";
+import type { Opaque } from "type-fest";
+import { cipher, encoder, hasher, Protocols } from "../transport/cryptionProtocols";
+import { HashStore } from "../transport/HashStore";
+import { logger } from "../logger";
+import { RawDecryptionError } from "../transport/errors/RawDecryptionError";
+import btoa from "btoa-lite";
+
+export type Hashed = Opaque<string, "Hashed">;
+
+// Vite rolls this into a single module on build, but uses modules at dev time.
+// FIXME: Firefox only supports module workers in FF 111. Meantime, test under Chromium.
+
+function derivePKey(password: string, salt: Salt): Obfuscated {
+	logger.debug("derivePKey started...");
+
+	const Cryption = Protocols.v0;
+	const result = new HashStore(
+		Cryption.derivation(password, salt, {
+			iterations: Cryption.iterations,
+			hasher: hasher(Cryption.hasher),
+			keySize: Cryption.keySizeBits / Cryption.wordSizeBits,
+		}).toString(encoder(Cryption.keyEncoding))
+	);
+
+	logger.debug("derivePKey finished");
+	return result.hashedValue;
+}
+
+function hashed(input: string): Hashed {
+	logger.debug("hashed started...");
+	const result = HashStore.fromHashed(derivePKey(input, "salt" as Salt)).hashedValue;
+
+	logger.debug("hashed finished");
+	return result as string as Hashed;
+}
+
+function deriveDEK(encodedPKey: Obfuscated, ciphertext: string): Obfuscated {
+	logger.debug("deriveDEK started...");
+
+	const dekObject = decrypt({ ciphertext }, encodedPKey);
+	if (typeof dekObject !== "string") throw RawDecryptionError.malformedKey();
+
+	const result = HashStore.fromHashed(dekObject as Obfuscated);
+
+	logger.debug("deriveDEK finished");
+	return result.hashedValue;
+}
+
+function newDataEncryptionKeyMaterialForDEK(password: string, encodedDek: Obfuscated): KeyMaterial {
+	logger.debug("newDataEncryptionKeyMaterialForDEK started...");
+
+	// To make passwords harder to guess
+	const dek = HashStore.fromHashed(encodedDek);
+	const Cryption = Protocols.v0;
+	const passSalt = btoa(Cryption.randomValue(Cryption.saltSizeBytes)) as Salt;
+
+	// To encrypt the dek
+	const pKey = derivePKey(password, passSalt);
+	const dekObject = btoa(dek.value);
+	const dekMaterial = encrypt(dekObject, "KeyMaterial", pKey).ciphertext as Obfuscated;
+
+	logger.debug("newDataEncryptionKeyMaterialForDEK finished");
+	return { dekMaterial, passSalt };
+}
+
+function newDataEncryptionKeyMaterial(password: string): KeyMaterial {
+	logger.debug("newDataEncryptionKeyMaterial started...");
+
+	// To encrypt data
+	const Cryption = Protocols.v0;
+	const dek = new HashStore(Cryption.randomValue(Cryption.keySizeBits / Cryption.wordSizeBits));
+
+	const result = newDataEncryptionKeyMaterialForDEK(password, dek.hashedValue);
+
+	logger.debug("newDataEncryptionKeyMaterial finished");
+	return result;
+}
+
+function newMaterialFromOldKey(
+	oldPassword: string,
+	newPassword: string,
+	oldKey: KeyMaterial
+): KeyMaterial {
+	logger.debug("newMaterialFromOldKey started...");
+
+	const oldPKey = derivePKey(oldPassword, oldKey.passSalt);
+	const dek = deriveDEK(oldPKey, oldKey.dekMaterial);
+	const newPKey = newDataEncryptionKeyMaterialForDEK(newPassword, dek);
+
+	logger.debug("newMaterialFromOldKey finished");
+	return {
+		dekMaterial: newPKey.dekMaterial,
+		passSalt: newPKey.passSalt,
+		oldDekMaterial: oldKey.dekMaterial,
+		oldPassSalt: oldKey.passSalt,
+	};
+}
+
+function encrypt<T extends string>(
+	data: unknown,
+	objectType: T,
+	encodedDek: Obfuscated
+): EPackage<T> {
+	logger.debug("encrypt started...");
+
+	const dek = HashStore.fromHashed(encodedDek);
+	const plaintext = JSON.stringify(data);
+	const Cryption = Protocols.v0;
+	const ciphertext = cipher(Cryption.cipher).encrypt(plaintext, dek.value).toString();
+
+	logger.debug("encrypt finished");
+	return { ciphertext, objectType, cryption: "v0" };
+}
+
+/**
+ * Deserializes encrypted data.
+ *
+ * @param pkg The object that was stored in the server.
+ * @param dek The data en/decryption key.
+ * @returns The original data.
+ */
+function decrypt(
+	pkg: Pick<EPackage<string>, "ciphertext" | "cryption">,
+	encodedDek: Obfuscated
+): unknown {
+	logger.debug("decrypt started...");
+
+	const dek = HashStore.fromHashed(encodedDek);
+	const { ciphertext, cryption } = pkg;
+	const protocol = cryption ?? "v0";
+	const Cryption = Protocols[protocol];
+	const plaintext = cipher(Cryption.cipher)
+		.decrypt(ciphertext, dek.value)
+		.toString(encoder(Cryption.dataEncoding));
+
+	if (!plaintext) {
+		logger.debug("decrypt finished");
+		throw RawDecryptionError.resultIsEmpty();
+	}
+
+	try {
+		return JSON.parse(plaintext) as unknown;
+	} catch (error) {
+		throw RawDecryptionError.parseFailed(error, plaintext);
+	} finally {
+		logger.debug("decrypt finished");
+	}
+}
+
+export {
+	derivePKey,
+	hashed,
+	deriveDEK,
+	newDataEncryptionKeyMaterial,
+	newMaterialFromOldKey,
+	encrypt,
+	decrypt,
+};


### PR DESCRIPTION
In preparation for possibly moving en/decryption operations into a Web Worker, we're abstracting out our basic cryption structures.