### PR TITLE
Fix keyboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.7] - 2023-10-22
+### Fixed
+- List items now properly take `Spacebar` and `Enter` keys as navigation directives, instead of taking _every_ key.
+
 ## [0.18.6] - 2023-10-21
 ### Fixed
 - The "Recent Locations" dropdown no longer just turns invisible while "closed". Mouse events should now work properly beneath the location selector while it's closed.
@@ -492,6 +496,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
+[0.18.7]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.6...v0.18.7
 [0.18.6]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.5...v0.18.6
 [0.18.5]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.4...v0.18.5
 [0.18.4]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.3...v0.18.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.18.6",
+	"version": "0.18.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recorded-finance-client",
-			"version": "0.18.6",
+			"version": "0.18.7",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.18.6",
+	"version": "0.18.7",
 	"license": "GPL-3.0",
 	"description": "A Svelte app for managing monetary assets.",
 	"scripts": {

--- a/src/components/ListItem.svelte
+++ b/src/components/ListItem.svelte
@@ -5,7 +5,7 @@
 
 	const dispatch = createEventDispatcher<{
 		click: MouseEvent;
-		keyup: KeyboardEvent;
+		keydown: KeyboardEvent;
 	}>();
 
 	type ListItemKind = "add" | "choose";
@@ -20,13 +20,20 @@
 	export let kind: ListItemKind = "choose";
 
 	function onClick(event: KeyboardEvent | MouseEvent) {
-		console.debug("onClick", to);
-		if (to) {
-			navigate(to, { replace });
-		} else if ("key" in event) {
-			dispatch("keyup", event);
+		if ("key" in event) {
+			// Keyboard event
+			dispatch("keydown", event);
+			if (to && (event.key.toLowerCase() === "enter" || event.key === " ")) {
+				event.preventDefault();
+				event.stopPropagation();
+				navigate(to, { replace });
+			}
 		} else {
+			// Mouse event
 			dispatch("click", event);
+			if (to) {
+				navigate(to, { replace });
+			}
 		}
 	}
 </script>
@@ -35,7 +42,7 @@
 	this={to === null ? "div" : "a"}
 	class="list-item {kind} {to !== null ? 'clickable' : ''}"
 	href={to}
-	on:keyup|stopPropagation|preventDefault={onClick}
+	on:keydown={onClick}
 	on:click|stopPropagation|preventDefault={onClick}
 >
 	<slot name="icon" />

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -16,7 +16,7 @@
 	}
 
 	function onClose(event: MouseEvent | KeyboardEvent) {
-		if ("key" in event && event.key !== "Escape") return;
+		if ("key" in event && event.key.toLowerCase() !== "escape") return;
 		doClose();
 	}
 
@@ -30,7 +30,7 @@
 		<div
 			transition:fly|local
 			class="modal-6ca181ee__wrapper"
-			on:keyup={onClose}
+			on:keydown={onClose}
 			on:click|self={onClose}
 		>
 			{#if closeModal}

--- a/src/components/inputs/ColorPicker.svelte
+++ b/src/components/inputs/ColorPicker.svelte
@@ -13,7 +13,7 @@
 		dispatch("change", colorId);
 	}
 
-	function onKeyup(event: CustomEvent<KeyboardEvent>, colorId: ColorID) {
+	function onKeydown(event: CustomEvent<KeyboardEvent>, colorId: ColorID) {
 		if (event.detail.key !== " ") return;
 		event.stopPropagation();
 		select(colorId);
@@ -24,7 +24,11 @@
 	<List>
 		{#each colors as colorId}
 			<li class={colorId === value ? "selected" : ""}>
-				<ColorDot {colorId} on:keyup={e => onKeyup(e, colorId)} on:click={() => select(colorId)}>
+				<ColorDot
+					{colorId}
+					on:keydown={e => onKeydown(e, colorId)}
+					on:click={() => select(colorId)}
+				>
 					<div class="check" />
 				</ColorDot>
 			</li>

--- a/src/components/inputs/StylizedCheckbox.svelte
+++ b/src/components/inputs/StylizedCheckbox.svelte
@@ -29,7 +29,7 @@
 	<label class="checkbox {loading ? 'loading' : ''}">
 		<label
 			class="mark {disabled ? 'disabled' : ''} {value ? 'checked' : ''}"
-			on:keyup={toggle}
+			on:keydown={toggle}
 			on:click|stopPropagation|preventDefault={toggle}
 		>
 			<input type="checkbox" checked={value} {disabled} on:change={onChange} />

--- a/src/pages/accounts/AccountListItem.svelte
+++ b/src/pages/accounts/AccountListItem.svelte
@@ -40,6 +40,6 @@
 	{subtitle}
 	count={remainingBalance ? toCurrency($locale.code, remainingBalance) : "--"}
 	negative={isBalanceNegative}
-	on:keyup
+	on:keydown
 	on:click
 />

--- a/src/pages/accounts/AccountView.svelte
+++ b/src/pages/accounts/AccountView.svelte
@@ -130,7 +130,7 @@
 		<List>
 			<li>
 				<AddRecordListItem
-					on:keyup={startCreatingTransaction}
+					on:keydown={startCreatingTransaction}
 					on:click={startCreatingTransaction}
 				/>
 			</li>

--- a/src/pages/accounts/Accounts.svelte
+++ b/src/pages/accounts/Accounts.svelte
@@ -67,7 +67,7 @@
 			<li>
 				<AddRecordListItem
 					noun="account"
-					on:keyup={startCreatingAccount}
+					on:keydown={startCreatingAccount}
 					on:click={startCreatingAccount}
 				/>
 			</li>

--- a/src/pages/accounts/AddRecordListItem.svelte
+++ b/src/pages/accounts/AddRecordListItem.svelte
@@ -6,20 +6,18 @@
 
 	const dispatch = createEventDispatcher<{
 		click: MouseEvent;
-		keyup: KeyboardEvent;
+		keydown: KeyboardEvent;
 	}>();
 
 	export let noun: string = "record";
 
-	function onClick(event: CustomEvent<MouseEvent> | CustomEvent<KeyboardEvent>) {
-		event.preventDefault();
-		event.detail.preventDefault();
+	function onKeydown(event: CustomEvent<KeyboardEvent>) {
+		dispatch("keydown", event.detail);
+	}
 
-		if ("key" in event.detail) {
-			dispatch("keyup", event.detail);
-		} else {
-			dispatch("click", event.detail);
-		}
+	function onClick(event: CustomEvent<MouseEvent>) {
+		event.preventDefault();
+		dispatch("click", event.detail);
 	}
 </script>
 
@@ -27,7 +25,7 @@
 	kind="add"
 	title={$_("actions.add-new-noun", { values: { noun } })}
 	to=""
-	on:keyup={onClick}
+	on:keydown={onKeydown}
 	on:click={onClick}
 >
 	<PlusWithCircle slot="icon" />

--- a/src/pages/attachments/FileListItem.svelte
+++ b/src/pages/attachments/FileListItem.svelte
@@ -11,7 +11,7 @@
 	const dispatch = createEventDispatcher<{
 		delete: Attachment;
 		"delete-reference": string;
-		keyup: KeyboardEvent;
+		keydown: KeyboardEvent;
 		click: MouseEvent;
 	}>();
 
@@ -36,7 +36,7 @@
 			if (event.detail.key === " ") {
 				isModalOpen = true;
 			}
-			dispatch("keyup", event.detail);
+			dispatch("keydown", event.detail);
 		} else {
 			dispatch("click", event.detail);
 			isModalOpen = true;
@@ -56,7 +56,7 @@
 	}
 </script>
 
-<ListItem {title} {subtitle} to="" on:keyup={presentImageModal} on:click={presentImageModal} />
+<ListItem {title} {subtitle} to="" on:keydown={presentImageModal} on:click={presentImageModal} />
 <Modal open={isModalOpen && !!file} {closeModal}>
 	<FileView {file} on:delete={askToDelete} on:deleteReference={askToDeleteReference} />
 </Modal>

--- a/src/pages/attachments/FileReattach.svelte
+++ b/src/pages/attachments/FileReattach.svelte
@@ -59,7 +59,7 @@
 				<ListItem
 					title={$_("files.upload.imperative")}
 					to=""
-					on:keyup={e => {
+					on:keydown={e => {
 						e.preventDefault();
 						e.detail.preventDefault();
 						if (e.detail.key === " ") {
@@ -78,7 +78,7 @@
 			<li>
 				<FileListItem
 					fileId={file.id}
-					on:keyup={e => {
+					on:keydown={e => {
 						e.preventDefault();
 						e.detail.preventDefault();
 						if (e.detail.key === " ") {

--- a/src/pages/locations/LocationListItem.svelte
+++ b/src/pages/locations/LocationListItem.svelte
@@ -7,7 +7,7 @@
 	export let quote: boolean = false;
 </script>
 
-<div class="location" title="id: {location.id}" on:keyup on:click>
+<div class="location" title="id: {location.id}" on:keydown on:click>
 	{#if location.coordinate}
 		<LocationIcon />
 	{:else}

--- a/src/pages/settings/ImportProcessModal.svelte
+++ b/src/pages/settings/ImportProcessModal.svelte
@@ -168,7 +168,7 @@
 							{account}
 							link={false}
 							count={transactionCounts[account.id] ?? 0}
-							on:keyup={e => toggleAccount(e, account)}
+							on:keydown={e => toggleAccount(e, account)}
 							on:click={e => toggleAccount(e, account)}
 						/>
 						{#if accountIdsToImport.has(account.id)}
@@ -191,7 +191,7 @@
 							{account}
 							link={false}
 							count={transactionCounts[account.id] ?? 0}
-							on:keyup={e => toggleAccount(e, account)}
+							on:keydown={e => toggleAccount(e, account)}
 							on:click={e => toggleAccount(e, account)}
 						/>
 						{#if accountIdsToImport.has(account.id)}

--- a/src/pages/tags/Tag.svelte
+++ b/src/pages/tags/Tag.svelte
@@ -21,7 +21,7 @@
 <div
 	class={`tag tag--${tag.colorId} ${onSelect ? "selectable" : ""}`}
 	title={tag.id}
-	on:keyup={e => selectTag(e, tag)}
+	on:keydown={e => selectTag(e, tag)}
 	on:click={e => selectTag(e, tag)}
 >
 	<span class="title">{tag.name}</span>

--- a/src/pages/transactions/MonthView.svelte
+++ b/src/pages/transactions/MonthView.svelte
@@ -43,7 +43,7 @@
 		<List>
 			<li>
 				<AddRecordListItem
-					on:keyup={startCreatingTransaction}
+					on:keydown={startCreatingTransaction}
 					on:click={startCreatingTransaction}
 				/>
 			</li>

--- a/src/pages/transactions/TransactionView.svelte
+++ b/src/pages/transactions/TransactionView.svelte
@@ -222,7 +222,7 @@
 					{:else}
 						<FileListItem
 							{fileId}
-							on:keyup={e => {
+							on:keydown={e => {
 								e.preventDefault();
 								e.detail.preventDefault();
 								if (e.detail.key === " ") {


### PR DESCRIPTION
Previously, list items would take _any_ keyboard input to be an actuation directive. This was a nightmare for keyboard navigation. Now, only `Spacebar` and `Enter` keys are treated this way. Tab navigation works now!