### PR TITLE
fix: Permit TOTP users to change their password without corrupting their auth data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.8] - 2023-10-30
 ### Changed
 - Replaced Jest with Vitest.
+
+### Fixed
+- Added Token field to "Change Password" form. Previously, the password change process would simply error out early, but still update the DEK. This leaves the account in a very weird state where the old password is required to enter the and download data, but the data may only be decrypted using the new password! Maybe one day I'll add a separate modal view to collect that password, to aid in getting out of this state, but for now, provide your TOTP token. And don't get it wrong, or bad things might happen! :D
 
 ## [0.18.7] - 2023-10-22
 ### Fixed
@@ -500,7 +503,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.7...HEAD
+[0.18.8]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.7...v0.18.8
 [0.18.7]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.6...v0.18.7
 [0.18.6]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.5...v0.18.6
 [0.18.5]: https://github.com/RecordedFinance/recorded-finance/compare/v0.18.4...v0.18.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.18.7",
+	"version": "0.18.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recorded-finance-client",
-			"version": "0.18.7",
+			"version": "0.18.8",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recorded-finance-client",
-	"version": "0.18.7",
+	"version": "0.18.8",
 	"license": "GPL-3.0",
 	"description": "A Svelte app for managing monetary assets.",
 	"scripts": {

--- a/src/pages/settings/ChangePasswordForm.svelte
+++ b/src/pages/settings/ChangePasswordForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { _ } from "../../i18n";
+	import { currentUser } from "../../store/authStore";
 	import { handleError } from "../../store";
 	import { toast } from "@zerodevx/svelte-toast";
 	import { updatePassword } from "../../store/authStore";
@@ -11,6 +12,7 @@
 	let currentPassword = "";
 	let newPassword = "";
 	let newPasswordRepeat = "";
+	let token = "";
 
 	$: hasChanges = currentPassword !== "" && newPassword !== "" && newPassword === newPasswordRepeat;
 
@@ -32,7 +34,7 @@
 
 			isLoading = true;
 
-			await updatePassword(currentPassword, newPassword);
+			await updatePassword(currentPassword, newPassword, token);
 			toast.push($_("settings.auth.passphrase-updated"), { classes: ["toast-success"] });
 			reset();
 		} catch (error) {
@@ -71,6 +73,16 @@
 		showsRequired={false}
 		required
 	/>
+	{#if $currentUser?.mfa.includes("totp")}
+		<TextField
+			value={token}
+			on:input={e => (token = e.detail)}
+			label={$_("login.totp")}
+			autocomplete="one-time-code"
+			showsRequired={false}
+			required
+		/>
+	{/if}
 
 	<div class="buttons">
 		<ActionButton type="submit" disabled={!hasChanges || isLoading}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -335,7 +335,11 @@ export async function regenerateAccountId(currentPassword: string): Promise<void
 	_isNewLogin.set(true);
 }
 
-export async function updatePassword(oldPassword: string, newPassword: string): Promise<void> {
+export async function updatePassword(
+	oldPassword: string,
+	newPassword: string,
+	token?: string
+): Promise<void> {
 	const user = auth.currentUser;
 	if (user === null) {
 		throw new PlatformError("auth/unauthenticated");
@@ -358,7 +362,7 @@ export async function updatePassword(oldPassword: string, newPassword: string): 
 
 	// Update auth password
 	try {
-		await _updatePassword(auth, user, await hashed(oldPassword), await hashed(newPassword));
+		await _updatePassword(auth, user, await hashed(oldPassword), await hashed(newPassword), token);
 	} catch (error) {
 		// Overwrite the new key with the old key, and have user try again
 		await setAuthMaterial(user.uid, oldMaterial);

--- a/src/transport/auth.ts
+++ b/src/transport/auth.ts
@@ -339,16 +339,24 @@ export async function updatePassword(
 	db: PlatformDB,
 	user: User,
 	oldPassword: string,
-	newPassword: string
+	newPassword: string,
+	token?: string
 ): Promise<void> {
 	if (!oldPassword)
 		throw new TypeError(t("error.sanity.empty-param", { values: { name: "oldPassword" } }));
 	if (!newPassword)
 		throw new TypeError(t("error.sanity.empty-param", { values: { name: "newPassword" } }));
 
-	await run(postV0Updatepassword, db, {
+	type Payload = Parameters<typeof postV0Updatepassword>[0];
+	const payload: Payload = {
 		account: user.accountId,
 		password: oldPassword,
 		newpassword: newPassword,
-	});
+	};
+
+	if (token) {
+		payload.token = token;
+	}
+
+	await run(postV0Updatepassword, db, payload);
 }


### PR DESCRIPTION
Adds Token field to "Change Password" form. Previously, the password change process would simply error out early, but still update the DEK. This leaves the account in a very weird state where the old password is required to enter the and download data, but the data may only be decrypted using the new password! Maybe one day I'll add a separate modal view to collect that password, to aid in getting out of this state, but for now, provide your TOTP token. And don't get it wrong, or bad things might happen! :D

Note: I plan to fix password change reliability well before v1.0. For now, this fix makes getting into the weird state much more difficult.